### PR TITLE
25-undo the last blur change on the image

### DIFF
--- a/src/components/ActionButton.tsx
+++ b/src/components/ActionButton.tsx
@@ -20,7 +20,7 @@ const ActionButton = ({
   return (
     <button
       onClick={onClick}
-      className={`cursor-pointer flex items-center gap-2 px-4 py-2 ${bgColor} ${textColor} rounded-md hover:${hoverColor} transition-colors`}
+      className={`cursor-pointer flex items-center gap-2 px-4 py-2 border ${bgColor} ${textColor} rounded-md hover:${hoverColor} transition-colors`}
     >
       {icon}
       {label}


### PR DESCRIPTION
As a user, when I have applied a blur or modification on the image, then I can undo the action to return to the previous state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an "undo blur" functionality in the image upload interface, allowing users to revert the last applied blur effect with a dedicated action button.
  
- **Style**
  - Enhanced the appearance of the action button by adding a border for improved visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->